### PR TITLE
Update to work with available ubuntu images

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Also, make sure you give the service account the Project Owner role.
 
 ## Usage/Workflow
 
+Optional: Set the UBUNTU_VERSION environment variable to select the [operating system version](https://cloud.google.com/compute/docs/images/os-details). Defaults to 'ubuntu-1804-lts'. 
+
 - Run `opsimulate setup` to setup the home `~/.opsimulate` directory that opsimulate generates artifacts in.
 - Run `opsimulate load_credentials <path to GCP-service-account-credentials.json>` to load in the GCP service account credentials.
 - Run `opsimulate deploy` to create the Gitlab instance and make it accessible.

--- a/full_requirements.txt
+++ b/full_requirements.txt
@@ -1,0 +1,11 @@
+click==6.7
+google-api-python-client==1.6.2
+httplib2==0.20.2
+oauth2client==4.1.3
+pyasn1==0.4.8
+pyasn1-modules==0.2.8
+pyparsing==2.4.7
+PyYAML==3.12
+rsa==4.5
+six==1.16.0
+uritemplate==3.0.1

--- a/opsimulate/constants.py
+++ b/opsimulate/constants.py
@@ -37,7 +37,7 @@ SERVICE_ACCOUNT_FILE = os.path.join(OPSIMULATE_HOME, 'service-account.json')
 
 ZONE = 'us-east4-a'
 MACHINE_TYPE = 'n1-standard-1'
-UBUNTU_VERSION = 'ubuntu-1404-lts'
+UBUNTU_VERSION = 'ubuntu-1804-lts'
 INSTANCE_NAME = 'opsimulate-gitlab'
 VM_USERNAME = 'opsimulate'
 GITLAB_TAG = 'gitlab'

--- a/opsimulate/constants.py
+++ b/opsimulate/constants.py
@@ -37,7 +37,7 @@ SERVICE_ACCOUNT_FILE = os.path.join(OPSIMULATE_HOME, 'service-account.json')
 
 ZONE = 'us-east4-a'
 MACHINE_TYPE = 'n1-standard-1'
-UBUNTU_VERSION = 'ubuntu-1804-lts'
+UBUNTU_VERSION = os.environ.get('UBUNTU_VERSION', 'ubuntu-1804-lts')
 INSTANCE_NAME = 'opsimulate-gitlab'
 VM_USERNAME = 'opsimulate'
 GITLAB_TAG = 'gitlab'


### PR DESCRIPTION
The image previously in use, 'ubuntu-1404-lts', is no longer hosted on google cloud. This updates the default version to 'ubuntu-1804-lts' and allows users to set the UBUNTU_VERSION environment variable if they desire a different image.